### PR TITLE
Fix: update scripts with more information

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
 # VKS Offline setup automation
 
-This directory contains multiple scripts that provide assistance to automate the various stages of the VKS setup in an airgapped setup. The names of the script should signify the stage at which each script should be run. There is a `config` folder that contains the necessary files for users to provide enviornmental configurations.  
+This directory contains multiple scripts that provide assistance to automate the various stages of the [VMware vSphere Kubernetes Service (VKS) setup in an airgapped setup](https://github.com/vsphere-tmm/vsphere-supervisor/blob/main/airgapped/air-gapped.md).
+The names of the script should signify the stage at which each script should be run. There is a `config` folder that contains the necessary files for users to provide environmental configurations.

--- a/bastion-download-kubernetes-rel.sh
+++ b/bastion-download-kubernetes-rel.sh
@@ -15,32 +15,31 @@ fi
 mkdir -p "$DOWNLOAD_VKR_OVA"
 
 echo
-echo "The VMware subscribed content library has the following Kubernetes Release images ... "
+echo "The VMware subscribed content library has the following Kubernetes Release images:"
 echo
 curl -s https://wp-content.vmware.com/v2/latest/items.json |jq -r '.items[]| .created + "\t" + .name'|sort
 
 echo
-echo "The list shown above is sorted by release date with the corrosponding names of the"
+echo "The list shown above is sorted by release date (last one is the most recent) with the corresponding names of the"
 echo "Kubernetes Release in the second column."
 read -p "Enter the name of the Kubernetes Release OVA that you want to download and zip for offline upload: " tkgrimage
 
 echo
-echo "Downloading all files for the TKG image: ${tkgrimage} ..."
+echo "Downloading all files for the TKG image: ${tkgrimage} into $DOWNLOAD_VKR_OVA ..."
 echo
-wget -q --show-progress --no-parent -r -nH --cut-dirs=2 --reject="index.html*" https://wp-content.vmware.com/v2/latest/"${tkgrimage}"/
+wget -q --show-progress --no-parent -r -nH --cut-dirs=2 --reject="index.html*" -P $DOWNLOAD_VKR_OVA https://wp-content.vmware.com/v2/latest/"${tkgrimage}"/
 
 echo "Compressing downloaded files..."
-tar -cvzf "${tkgrimage}".tar.gz "${tkgrimage}"
+tar -cvzf "$DOWNLOAD_VKR_OVA/${tkgrimage}".tar.gz "$DOWNLOAD_VKR_OVA/${tkgrimage}"
 
 echo
 echo "Cleaning up..."
-[ -d "${tkgrimage}" ] && rm -rf "${tkgrimage}"
-mv "${tkgrimage}".tar.gz "${DOWNLOAD_VKR_OVA}" 
+[ -d "$DOWNLOAD_VKR_OVA/${tkgrimage}" ] && rm -rf "$DOWNLOAD_VKR_OVA/${tkgrimage}/"
 
-echo "Copy the file ${tkgrimage}.tar.gz to the offline admin machine that has access to the vSphere environment."
-echo "You can untar the file and upload the OVA files to a Content Library called Local..."
-echo "Optionally, you can install and configure govc on the offline admin machine."
-echo "Use the following command on the admin machine to import the image to the vCenter Content Library called "Local"..."
+echo "Copy the file ${DOWNLOAD_VKR_OVA}/${tkgrimage}.tar.gz to the offline admin machine that has access to the vSphere environment."
+echo "You can untar the file and upload the OVA files to a Content Library called \"Local\""
+echo "Optionally, you can install and configure govc (https://github.com/vmware/govmomi/tree/main/govc) on the offline admin machine:"
+echo "Use the following command on the admin machine to import the image to the vCenter Content Library called \"Local\":"
 echo
 echo "     tar -xzvf ${tkgrimage}.tar.gz"
 echo "     cd ${tkgrimage}"


### PR DESCRIPTION
- Add some more links to find the binaries used in the script
- Avoid moving files around, download in the final location right away

Testing Done: Ran the 2 scripts:
```
$ ./bastion-download-kubernetes-rel.sh
```
and
```
$ ./bastion-download-prerequisites.sh
```
(note that I'm on Mac to try this, so not looking at the CLI plugins since ~/.local/share/tanzu-cli/ does not exist there, plugins are under ~/Library/Application Support/tanzu)